### PR TITLE
Fix invalid image urls in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,20 @@ The following figure shows two different views of the HIV life cycle (contains 7
 Here are more examples:
 
 The data is the RAF Cascade pathway. A Venn diagram is supplied on  the right to provide an overview of the types of interactions within the pathway. The size of circles in this diagram represents the frequency of different relations in the pathway, and overlapping areas provide an overview of how often relations co-exist in the pathway. We use the same color encoding for the Venn diagram and the matrix. For example, red represents "controls-state-change-of" relationships and blue represents "neighbor of" relationships.
-![ScreenShot](http://www.cs.uic.edu/~tdang/PathwayMatrix/Image1-RAF Cascade.png)
+![ScreenShot](http://www.cs.uic.edu/~tdang/PathwayMatrix/Image1-RAF%20Cascade.png)
 
 In the next figure, the data is the Influenza Infection pathway.
-![ScreenShot](http://www.cs.uic.edu/~tdang/PathwayMatrix/Image2-Influenza Infection.png)
+![ScreenShot](http://www.cs.uic.edu/~tdang/PathwayMatrix/Image2-Influenza%20Infection.png)
 
 In the next figure, the data is the ERBB2 pathway.  Lensing is applied on a middle section of the matrix.
 ![ScreenShot](http://www.cs.uic.edu/~tdang/PathwayMatrix/Image3-ERBB2.png)
 
 In the next figure, the data is the Replication of DNA pathway. The protein ordering algorithm enables similar proteins to locate next to each other to reveal cluster structures.
 
-![ScreenShot](http://www.cs.uic.edu/~tdang/PathwayMatrix/Image4-Replication of DNA.png)
+![ScreenShot](http://www.cs.uic.edu/~tdang/PathwayMatrix/Image4-Replication%20of%20DNA.png)
 
 In the next figure, the data is the Signaling to TGF pathway.
-![ScreenShot](http://www.cs.uic.edu/~tdang/PathwayMatrix/Image5-Signalling to TGF.png)
+![ScreenShot](http://www.cs.uic.edu/~tdang/PathwayMatrix/Image5-Signalling%20to%20TGF.png)
 
 
 Please click to watch the overview video.


### PR DESCRIPTION
This PR fixes the invalid image urls in the readme by encoding the illegal space characters as `%20`.